### PR TITLE
Feat: Member, Item, Review, Bookmark 엔티티 스키마 추가 및 고도화

### DIFF
--- a/knock-backend/core/core-api/src/main/java/com/knock/core/api/controller/v1/ItemController.java
+++ b/knock-backend/core/core-api/src/main/java/com/knock/core/api/controller/v1/ItemController.java
@@ -2,7 +2,6 @@ package com.knock.core.api.controller.v1;
 
 import com.knock.auth.MemberPrincipal;
 import com.knock.core.api.controller.v1.request.ItemCreateRequestDto;
-import com.knock.core.api.controller.v1.response.ItemCreateResponseDto;
 import com.knock.core.domain.item.ItemService;
 import com.knock.core.domain.item.dto.ItemCreateData;
 import com.knock.core.domain.item.dto.ItemCreateResult;

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/Bookmark.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/Bookmark.java
@@ -1,0 +1,40 @@
+package com.knock.storage.db.core.bookmark;
+
+import com.knock.storage.db.core.BaseEntity;
+import com.knock.storage.db.core.item.Item;
+import com.knock.storage.db.core.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "bookmark", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "member_id", "item_id" })
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE bookmark SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Bookmark extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    private Bookmark(Member member, Item item) {
+        this.member = member;
+        this.item = item;
+    }
+
+    public static Bookmark create(Member member, Item item) {
+        return new Bookmark(member, item);
+    }
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkJpaRepository.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkJpaRepository.java
@@ -1,0 +1,20 @@
+package com.knock.storage.db.core.bookmark;
+
+import com.knock.storage.db.core.item.Item;
+import com.knock.storage.db.core.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
+
+    Optional<Bookmark> findByMemberAndItem(Member member, Item item);
+
+    boolean existsByMemberAndItem(Member member, Item item);
+
+    List<Bookmark> findByMemberId(Long memberId);
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkRepository.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkRepository.java
@@ -1,0 +1,19 @@
+package com.knock.storage.db.core.bookmark;
+
+import com.knock.storage.db.core.item.Item;
+import com.knock.storage.db.core.member.Member;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BookmarkRepository {
+
+    Bookmark save(Bookmark bookmark);
+
+    void delete(Bookmark bookmark);
+
+    Optional<Bookmark> findByMemberAndItem(Member member, Item item);
+
+    List<Bookmark> findByMemberId(Long memberId);
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkRepositoryImpl.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/bookmark/BookmarkRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.knock.storage.db.core.bookmark;
+
+import com.knock.storage.db.core.item.Item;
+import com.knock.storage.db.core.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkRepositoryImpl implements BookmarkRepository {
+
+    private final BookmarkJpaRepository jpaRepository;
+
+    @Override
+    public Bookmark save(Bookmark bookmark) {
+        return jpaRepository.save(bookmark);
+    }
+
+    @Override
+    public void delete(Bookmark bookmark) {
+        jpaRepository.delete(bookmark);
+    }
+
+    @Override
+    public Optional<Bookmark> findByMemberAndItem(Member member, Item item) {
+        return jpaRepository.findByMemberAndItem(member, item);
+    }
+
+    @Override
+    public List<Bookmark> findByMemberId(Long memberId) {
+        return jpaRepository.findByMemberId(memberId);
+    }
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/Group.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/Group.java
@@ -36,6 +36,9 @@ public class Group extends BaseEntity {
 	@Column(name = "invite_code_expires_at")
 	private LocalDateTime inviteCodeExpiresAt;
 
+	@Column(name = "cover_image")
+	private String coverImage;
+
 	private Group(String name, String description, String inviteCode, Long ownerId, boolean isPersonal) {
 		this.name = name;
 		this.description = description;

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/GroupMember.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/GroupMember.java
@@ -31,9 +31,7 @@ public class GroupMember extends BaseEntity {
 	private GroupRole role; // ADMIN, MEMBER
 
 	public enum GroupRole {
-
 		ADMIN, MEMBER
-
 	}
 
 	@Builder

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/GroupRepositoryImpl.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/group/GroupRepositoryImpl.java
@@ -13,8 +13,7 @@ public class GroupRepositoryImpl implements GroupRepository {
 
 	private final GroupMemberJpaRepository groupMemberJpaRepository;
 
-	public GroupRepositoryImpl(GroupJpaRepository groupJpaRepository,
-			GroupMemberJpaRepository groupMemberJpaRepository) {
+	public GroupRepositoryImpl(GroupJpaRepository groupJpaRepository, GroupMemberJpaRepository groupMemberJpaRepository) {
 		this.groupJpaRepository = groupJpaRepository;
 		this.groupMemberJpaRepository = groupMemberJpaRepository;
 	}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/item/Item.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/item/Item.java
@@ -50,6 +50,10 @@ public class Item extends BaseEntity {
 	@Column(nullable = false)
 	private ItemStatus status;
 
+	// todo: 조회 로직에 대해서 고민 e.g. 세션 기반으로 한 사용자당 30분마다 +1
+	@Column(name = "view_count")
+	private Long viewCount;
+
 	public Item(Group group, Member member, String title, String description, Long price, ItemType type,
 			ItemCategory category) {
 		this.group = group;
@@ -60,6 +64,7 @@ public class Item extends BaseEntity {
 		this.type = type;
 		this.category = category;
 		this.status = ItemStatus.ON_SALE;
+		this.viewCount = 0L;
 	}
 
 	public static Item create(Group group, Member member, String title, String description, Long price, ItemType type,

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/item/ItemImage.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/item/ItemImage.java
@@ -24,16 +24,16 @@ public class ItemImage extends BaseEntity {
 	private String imageUrl;
 
 	@Column(name = "order_seq")
-	private int orderSeq;
+	private int orderSequence;
 
-	public ItemImage(Item item, String imageUrl, int orderSeq) {
+	public ItemImage(Item item, String imageUrl, int orderSequence) {
 		this.item = item;
 		this.imageUrl = imageUrl;
-		this.orderSeq = orderSeq;
+		this.orderSequence = orderSequence;
 	}
 
-	public static ItemImage create(Item item, String imageUrl, int orderSeq) {
-		return new ItemImage(item, imageUrl, orderSeq);
+	public static ItemImage create(Item item, String imageUrl, int orderSequence) {
+		return new ItemImage(item, imageUrl, orderSequence);
 	}
 
 }

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/member/Member.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/member/Member.java
@@ -35,15 +35,23 @@ public class Member extends BaseEntity {
 	@Column(nullable = false)
 	private String provider; // kakao, google etc.
 
+	@Column(name = "provider_id")
+	private String providerId;
+
+	@Column(name = "manner_temperature")
+	private Double mannerTemperature;
+
 	@Builder
 	public Member(String email, String password, String name, String nickname, String profileImageUrl,
-			String provider) {
+			String provider, String providerId) {
 		this.email = email;
 		this.password = password;
 		this.name = name;
 		this.nickname = nickname;
 		this.profileImageUrl = profileImageUrl;
 		this.provider = provider;
+		this.providerId = providerId;
+		this.mannerTemperature = 36.5;
 	}
 
 	public void updateProfile(String nickname, String profileImageUrl) {

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/Review.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/Review.java
@@ -1,0 +1,52 @@
+package com.knock.storage.db.core.review;
+
+import com.knock.storage.db.core.BaseEntity;
+import com.knock.storage.db.core.member.Member;
+import com.knock.storage.db.core.reservation.Reservation;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE review SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Review extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private Member reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private Member reviewee;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    private Review(Reservation reservation, Member reviewer, Member reviewee, String content, Integer score) {
+        this.reservation = reservation;
+        this.reviewer = reviewer;
+        this.reviewee = reviewee;
+        this.content = content;
+        this.score = score;
+    }
+
+    public static Review create(Reservation reservation, Member reviewer, Member reviewee, String content,
+            Integer score) {
+        return new Review(reservation, reviewer, reviewee, content, score);
+    }
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewJpaRepository.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewJpaRepository.java
@@ -1,0 +1,15 @@
+package com.knock.storage.db.core.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findByRevieweeId(Long revieweeId);
+
+    boolean existsByReservationId(Long reservationId);
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewRepository.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewRepository.java
@@ -1,0 +1,13 @@
+package com.knock.storage.db.core.review;
+
+import java.util.List;
+
+public interface ReviewRepository {
+
+    Review save(Review review);
+
+    List<Review> findByRevieweeId(Long revieweeId);
+
+    boolean existsByReservationId(Long reservationId);
+
+}

--- a/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewRepositoryImpl.java
+++ b/knock-backend/storage/db-core/src/main/java/com/knock/storage/db/core/review/ReviewRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.knock.storage.db.core.review;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+    private final ReviewJpaRepository jpaRepository;
+
+    @Override
+    public Review save(Review review) {
+        return jpaRepository.save(review);
+    }
+
+    @Override
+    public List<Review> findByRevieweeId(Long revieweeId) {
+        return jpaRepository.findByRevieweeId(revieweeId);
+    }
+
+    @Override
+    public boolean existsByReservationId(Long reservationId) {
+        return jpaRepository.existsByReservationId(reservationId);
+    }
+
+}


### PR DESCRIPTION
### 연관된 Issue

#2 

### 변경사항

이슈에서 다룬 4개의 태스크를 통해서 아래의 내용을 구현했습니다.

- Member Entity: providerId (소셜 로그인 식별자), mannerTemperature (매너온도) 컬럼 추가
- Item Entity: viewCount (조회수), coverImage (그룹 커버 이미지 - Group 엔티티) 추가 확인
- Bookmark Entity: 신규 생성 (Member - Item N:M 매핑, Unique 제약조건 필수)
- Review Entity: 신규 생성 (Reservation 1:1 매핑 권장, score, content 포함)

또한 기준 중 하나인 북마크의 (item_id, member_id)에 unique 제약조건을 걸어서 db 레벨에서 중복되는 데이터 없도록 처리했습니다.
